### PR TITLE
Update scheduled workflow time and Helm version

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -2,8 +2,8 @@ name: "Updatecli: Dependency Management"
 
 on:
   schedule:
-    # Run every hour
-    - cron: '0 * * * *'
+    # Runs at 12:00
+    - cron: '0 12 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -30,7 +30,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'latest'
+          version: 'v3.10.2'
 
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ We use Updatecli for this automation, instead of Dependabot or Renovate, because
 
 For detailed information on how to use Updatecli, please consult its [documentation](https://www.updatecli.io/docs/prologue/introduction/) page.
 
+## Scheduled workflow
+
+The automation runs as a GitHub Actions scheduled workflow once per day.
+
+Manual execution of the pipelines can be [triggered](https://github.com/rancherlabs/updatecli-automation/actions/workflows/updatecli.yml) when needed.
+
 ## Scope
 
 All Rancher owned repositories in [Rancher](https://github.com/rancher) and [Rancher Labs](https://github.com/rancherlabs) can be targeted by this automation.


### PR DESCRIPTION
Changes:

- [x] Update scheduled workflow time to run once a day, to avoid waste and because of the current token issue.
- [x] Update README to reflect this change.
- [x] Specify Helm version used by action `azure/setup-helm@v3` to avoid `Error while fetching latest Helm release: Error: [@octokit/auth-action] GITHUB_TOKEN variable is not set`. Explanation is available in https://github.com/azure/setup-helm#example.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>