### PR TITLE
Update Helm and Kustomize update pipelines for Rancher

### DIFF
--- a/updatecli/updatecli.d/rancher/rancher/v2.6/helm.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.6/helm.yaml
@@ -11,6 +11,8 @@ scms:
       owner: "rancher"
       repository: "rancher"
       branch: "release/v2.6"
+      commitmessage:
+        title: "Bump Helm version"
 
 pullrequests:
   github:
@@ -55,23 +57,14 @@ conditions:
         matcher: "HELM_VERSION"
 
 targets:
-  dockerfile-dapper:
+  dockerfiles:
     name: "Bump Helm version"
-    kind: "dockerfile"
+    kind: "file"
     scmid: "rancher"
     sourceid: "helm"
     spec:
-      file: "Dockerfile.dapper"
-      instruction:
-        keyword: "ENV"
-        matcher: "HELM_VERSION"
-  package-dockerfile:
-    name: "Bump Helm version"
-    kind: "dockerfile"
-    scmid: "rancher"
-    sourceid: "helm"
-    spec:
-      file: "package/Dockerfile"
-      instruction:
-        keyword: "ENV"
-        matcher: "HELM_VERSION"
+      files:
+        - "Dockerfile.dapper"
+        - "package/Dockerfile"
+      matchpattern: 'ENV HELM_VERSION v\d+\.\d+\.\d+(-\w+)?'
+      replacepattern: 'ENV HELM_VERSION {{ source "helm" }}'

--- a/updatecli/updatecli.d/rancher/rancher/v2.6/kustomize.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.6/kustomize.yaml
@@ -11,6 +11,8 @@ scms:
       owner: "rancher"
       repository: "rancher"
       branch: "release/v2.6"
+      commitmessage:
+        title: "Bump Kustomize version"
 
 pullrequests:
   github:
@@ -32,6 +34,8 @@ sources:
       versionfilter:
         kind: "regex"
         pattern: "kustomize/v.*"
+    transformers:
+      - trimprefix: "kustomize/"
 
 conditions:
   dockerfile-dapper:
@@ -56,27 +60,14 @@ conditions:
         matcher: "KUSTOMIZE_VERSION"
 
 targets:
-  dockerfile-dapper:
+  dockerfiles:
     name: "Bump Kustomize version"
-    kind: "dockerfile"
+    kind: "file"
     scmid: "rancher"
     sourceid: "kustomize"
     spec:
-      file: "Dockerfile.dapper"
-      instruction:
-        keyword: "ENV"
-        matcher: "KUSTOMIZE_VERSION"
-    transformers:
-      - trimprefix: "kustomize/"
-  package-dockerfile:
-    name: "Bump Kustomize version"
-    kind: "dockerfile"
-    scmid: "rancher"
-    sourceid: "kustomize"
-    spec:
-      file: "package/Dockerfile"
-      instruction:
-        keyword: "ENV"
-        matcher: "KUSTOMIZE_VERSION"
-    transformers:
-      - trimprefix: "kustomize/"
+      files:
+        - "Dockerfile.dapper"
+        - "package/Dockerfile"
+      matchpattern: 'ENV KUSTOMIZE_VERSION v\d+\.\d+\.\d+(-\w+)?'
+      replacepattern: 'ENV KUSTOMIZE_VERSION {{ source "kustomize" }}'

--- a/updatecli/updatecli.d/rancher/rancher/v2.7/helm.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.7/helm.yaml
@@ -11,6 +11,8 @@ scms:
       owner: "rancher"
       repository: "rancher"
       branch: "release/v2.7"
+      commitmessage:
+        title: "Bump Helm version"
 
 pullrequests:
   github:
@@ -55,23 +57,14 @@ conditions:
         matcher: "HELM_VERSION"
 
 targets:
-  dockerfile-dapper:
+  dockerfiles:
     name: "Bump Helm version"
-    kind: "dockerfile"
+    kind: "file"
     scmid: "rancher"
     sourceid: "helm"
     spec:
-      file: "Dockerfile.dapper"
-      instruction:
-        keyword: "ENV"
-        matcher: "HELM_VERSION"
-  package-dockerfile:
-    name: "Bump Helm version"
-    kind: "dockerfile"
-    scmid: "rancher"
-    sourceid: "helm"
-    spec:
-      file: "package/Dockerfile"
-      instruction:
-        keyword: "ENV"
-        matcher: "HELM_VERSION"
+      files:
+        - "Dockerfile.dapper"
+        - "package/Dockerfile"
+      matchpattern: 'ENV HELM_VERSION v\d+\.\d+\.\d+(-\w+)?'
+      replacepattern: 'ENV HELM_VERSION {{ source "helm" }}'

--- a/updatecli/updatecli.d/rancher/rancher/v2.7/kustomize.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.7/kustomize.yaml
@@ -11,6 +11,8 @@ scms:
       owner: "rancher"
       repository: "rancher"
       branch: "release/v2.7"
+      commitmessage:
+         title: "Bump Kustomize version"
 
 pullrequests:
   github:
@@ -32,6 +34,8 @@ sources:
       versionfilter:
         kind: "regex"
         pattern: "kustomize/v.*"
+    transformers:
+      - trimprefix: "kustomize/"
 
 conditions:
   dockerfile-dapper:
@@ -56,27 +60,14 @@ conditions:
         matcher: "KUSTOMIZE_VERSION"
 
 targets:
-  dockerfile-dapper:
+  dockerfiles:
     name: "Bump Kustomize version"
-    kind: "dockerfile"
+    kind: "file"
     scmid: "rancher"
     sourceid: "kustomize"
     spec:
-      file: "Dockerfile.dapper"
-      instruction:
-        keyword: "ENV"
-        matcher: "KUSTOMIZE_VERSION"
-    transformers:
-      - trimprefix: "kustomize/"
-  package-dockerfile:
-    name: "Bump Kustomize version"
-    kind: "dockerfile"
-    scmid: "rancher"
-    sourceid: "kustomize"
-    spec:
-      file: "package/Dockerfile"
-      instruction:
-        keyword: "ENV"
-        matcher: "KUSTOMIZE_VERSION"
-    transformers:
-      - trimprefix: "kustomize/"
+      files:
+        - "Dockerfile.dapper"
+        - "package/Dockerfile"
+      matchpattern: 'ENV KUSTOMIZE_VERSION v\d+\.\d+\.\d+(-\w+)?'
+      replacepattern: 'ENV KUSTOMIZE_VERSION {{ source "kustomize" }}'


### PR DESCRIPTION
Update Helm and Kustomize update pipelines for Rancher to address internal feedback:

- Make only one commit in the PR.
- Don't add the `=` sign between the env var name and its value.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>