### PR TITLE
Switch HelmProjectOperator to use file and regex instead of YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 tmpdir-*

--- a/updatecli/updatecli.d/rancher/shell/helm-project-operator/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/helm-project-operator/shell.yaml
@@ -21,6 +21,8 @@ scms:
       owner: "rancher"
       repository: "helm-project-operator"
       branch: "main"
+      commitmessage:
+         title: "Bump rancher/shell image version"
 
 pullrequests:
   github:
@@ -57,11 +59,11 @@ conditions:
 targets:
   chart:
     name: "Bump rancher/shell image version"
-    kind: "yaml"
+    kind: "file"
     scmid: "helm-project-operator"
     sourceid: "shell"
     spec:
       file: "charts/helm-project-operator/values.yaml"
-      key: "cleanup[0].image.tag"
-      value: '{{ source "shell" }}'
+      matchpattern: '(repository:\s+rancher\/shell\n\s+tag:)\s+.*'
+      replacepattern: '$1 {{ source "shell" }}'
 


### PR DESCRIPTION
This is to address internal feedback regarding PR https://github.com/rancher/helm-project-operator/pull/23/files where `kind: yaml` generated too much noise with formatting. `kind: "file"` with regex is also more powerful.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>