### PR TITLE
Update configuration key 'pullrequests' to 'actions'

### DIFF
--- a/updatecli/updatecli.d/rancher/rancher/v2.6/helm.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.6/helm.yaml
@@ -12,10 +12,10 @@ scms:
       repository: "rancher"
       branch: "release/v2.6"
 
-pullrequests:
+actions:
   github:
     title: "Bump Helm version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "rancher"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/rancher/v2.6/kustomize.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.6/kustomize.yaml
@@ -12,10 +12,10 @@ scms:
       repository: "rancher"
       branch: "release/v2.6"
 
-pullrequests:
+actions:
   github:
     title: "Bump Kustomize version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "rancher"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/rancher/v2.7/helm.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.7/helm.yaml
@@ -12,10 +12,10 @@ scms:
       repository: "rancher"
       branch: "release/v2.7"
 
-pullrequests:
+actions:
   github:
     title: "Bump Helm version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "rancher"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/rancher/v2.7/kustomize.yaml
+++ b/updatecli/updatecli.d/rancher/rancher/v2.7/kustomize.yaml
@@ -12,10 +12,10 @@ scms:
       repository: "rancher"
       branch: "release/v2.7"
 
-pullrequests:
+actions:
   github:
     title: "Bump Kustomize version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "rancher"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/shell/helm-project-operator/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/helm-project-operator/shell.yaml
@@ -22,9 +22,9 @@ scms:
       repository: "helm-project-operator"
       branch: "main"
 
-pullrequests:
+actions:
   github:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "helm-project-operator"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/shell/k9s.yaml
+++ b/updatecli/updatecli.d/rancher/shell/k9s.yaml
@@ -12,9 +12,9 @@ scms:
       repository: "shell"
       branch: "master"
 
-pullrequests:
+actions:
   github:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "shell"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/shell/kustomize.yaml
+++ b/updatecli/updatecli.d/rancher/shell/kustomize.yaml
@@ -12,9 +12,9 @@ scms:
       repository: "shell"
       branch: "master"
 
-pullrequests:
+actions:
   github:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "shell"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/shell/prometheus-federator/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/prometheus-federator/shell.yaml
@@ -34,10 +34,10 @@ scms:
       branch: "main"
       directory: "tmpdir-prometheus-federator/helm-project-operator"
 
-pullrequests:
+actions:
   github:
     title: "Bump rancher/shell image version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "prometheus-federator"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/shell/rancher/v2.6/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/rancher/v2.6/shell.yaml
@@ -22,10 +22,10 @@ scms:
       repository: "rancher"
       branch: "release/v2.6"
 
-pullrequests:
+actions:
   github:
     title: "Bump rancher/shell image version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "rancher"
     spec:
       automerge: false

--- a/updatecli/updatecli.d/rancher/shell/rancher/v2.7/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/rancher/v2.7/shell.yaml
@@ -22,10 +22,10 @@ scms:
       repository: "rancher"
       branch: "release/v2.7"
 
-pullrequests:
+actions:
   github:
     title: "Update rancher/shell image version"
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "rancher"
     spec:
       automerge: false


### PR DESCRIPTION
Configuration key 'pullrequests' is being deprecated. See https://github.com/updatecli/updatecli/releases/tag/v0.40.0.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>