### PR TITLE
Temporarily remove `rancher/shell` image bump in `prometheus-federator`

### DIFF
--- a/updatecli/updatecli.d/rancher/shell/prometheus-federator/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/prometheus-federator/shell.yaml
@@ -1,132 +1,132 @@
----
-name: "Bump rancher/shell image version"
-scms:
-  shell:
-    kind: "github"
-    spec:
-      user: "{{ .github.user }}"
-      email: "{{ .github.email }}"
-      username: "{{ .github.username }}"
-      token: "{{ requiredEnv .github.token }}"
-      owner: "rancher"
-      repository: "shell"
-      branch: "master"
-  prometheus-federator:
-    kind: "github"
-    spec:
-      user: "{{ .github.user }}"
-      email: "{{ .github.email }}"
-      username: "{{ .github.username }}"
-      token: "{{ requiredEnv .github.token }}"
-      owner: "rancher"
-      repository: "prometheus-federator"
-      branch: "main"
-      directory: "tmpdir-prometheus-federator/prometheus-federator"
-  helm-project-operator:
-    kind: "github"
-    spec:
-      user: "{{ .github.user }}"
-      email: "{{ .github.email }}"
-      username: "{{ .github.username }}"
-      token: "{{ requiredEnv .github.token }}"
-      owner: "rancher"
-      repository: "helm-project-operator"
-      branch: "main"
-      directory: "tmpdir-prometheus-federator/helm-project-operator"
-
-actions:
-  github:
-    title: "Bump rancher/shell image version"
-    kind: "github/pullrequest"
-    scmid: "prometheus-federator"
-    spec:
-      automerge: false
-
-sources:
-  shell-git-tag:
-    name: "Get rancher/shell image latest or -rc version"
-    kind: "gittag"
-    scmid: "shell"
-    spec:
-      versionfilter:
-        kind: "latest"
-  helm-project-operator-commit-hash:
-    name: "Get commit hash"
-    kind: "shell"
-    dependson:
-      - "shell-git-tag"
-    scmid: "helm-project-operator"
-    sourceid: "shell-git-tag"
-    spec:
-      command: '../../updatecli/scripts/prometheus-federator-retrieve-commit-hash.sh {{ source "shell-git-tag" }}'
-  prometheus-federator-release:
-    name: "Get prometheus-federator latest release"
-    kind: "githubrelease"
-    spec:
-      owner: "rancher"
-      repository: "prometheus-federator"
-      token: "{{ requiredEnv .github.token }}"
-      branch: "main"
-      versionfilter:
-        kind: "latest"
-    transformers:
-      - trimprefix: "v"
-
-conditions:
-  shell-image-dockerhub:
-    name: "Check rancher/shell image version in DockerHub"
-    kind: "dockerimage"
-    sourceid: "shell-git-tag"
-    spec:
-      image: "rancher/shell"
-  shell-image-helm-project-1:
-    name: "Check rancher/shell image version in Helm Project Operator chart"
-    kind: "yaml"
-    scmid: "helm-project-operator"
-    disablesourceinput: true
-    spec:
-      file: "charts/helm-project-operator/values.yaml"
-      key: "cleanup[0].image.repository"
-      value: "rancher/shell"
-  shell-image-helm-project-2:
-    name: "Check rancher/shell image version in Helm Project Operator chart"
-    kind: "yaml"
-    scmid: "helm-project-operator"
-    sourceid: "shell-git-tag"
-    spec:
-      file: "charts/helm-project-operator/values.yaml"
-      key: "cleanup[0].image.tag"
-  shell-image-prometheus-federator:
-    name: "Check rancher/shell image in prometheus-federator"
-    kind: "yaml"
-    scmid: "prometheus-federator"
-    disablesourceinput: true
-    spec:
-      file: 'charts/prometheus-federator/{{ source "prometheus-federator-release" }}/charts/helmProjectOperator/values.yaml'
-      key: "cleanup[0].image.repository"
-      value: "rancher/shell"
-
-targets:
-  commit-bump-version:
-    name: "Update Helm Project Generator go.mod and git commit version"
-    kind: "shell"
-    scmid: "prometheus-federator"
-    sourceid: "helm-project-operator-commit-hash"
-    spec:
-      command: "../../updatecli/scripts/prometheus-federator-update-commit-hash.sh"
-      environments:
-        - name: PATH
-        - name: HOME
-  commit-make-chart:
-    name: "Make Prometheus Federator chart"
-    kind: "shell"
-    scmid: "prometheus-federator"
-    dependson:
-      - "commit-bump-version"
-    disablesourceinput: true
-    spec:
-      command: "../../updatecli/scripts/prometheus-federator-make-chart.sh"
-      environments:
-        - name: PATH
-        - name: HOME
-
+#---
+#name: "Bump rancher/shell image version"
+#scms:
+#  shell:
+#    kind: "github"
+#    spec:
+#      user: "{{ .github.user }}"
+#      email: "{{ .github.email }}"
+#      username: "{{ .github.username }}"
+#      token: "{{ requiredEnv .github.token }}"
+#      owner: "rancher"
+#      repository: "shell"
+#      branch: "master"
+#  prometheus-federator:
+#    kind: "github"
+#    spec:
+#      user: "{{ .github.user }}"
+#      email: "{{ .github.email }}"
+#      username: "{{ .github.username }}"
+#      token: "{{ requiredEnv .github.token }}"
+#      owner: "rancher"
+#      repository: "prometheus-federator"
+#      branch: "main"
+#      directory: "tmpdir-prometheus-federator/prometheus-federator"
+#  helm-project-operator:
+#    kind: "github"
+#    spec:
+#      user: "{{ .github.user }}"
+#      email: "{{ .github.email }}"
+#      username: "{{ .github.username }}"
+#      token: "{{ requiredEnv .github.token }}"
+#      owner: "rancher"
+#      repository: "helm-project-operator"
+#      branch: "main"
+#      directory: "tmpdir-prometheus-federator/helm-project-operator"
+#
+#actions:
+#  github:
+#    title: "Bump rancher/shell image version"
+#    kind: "github/pullrequest"
+#    scmid: "prometheus-federator"
+#    spec:
+#      automerge: false
+#
+#sources:
+#  shell-git-tag:
+#    name: "Get rancher/shell image latest or -rc version"
+#    kind: "gittag"
+#    scmid: "shell"
+#    spec:
+#      versionfilter:
+#        kind: "latest"
+#  helm-project-operator-commit-hash:
+#    name: "Get commit hash"
+#    kind: "shell"
+#    dependson:
+#      - "shell-git-tag"
+#    scmid: "helm-project-operator"
+#    sourceid: "shell-git-tag"
+#    spec:
+#      command: '../../updatecli/scripts/prometheus-federator-retrieve-commit-hash.sh {{ source "shell-git-tag" }}'
+#  prometheus-federator-release:
+#    name: "Get prometheus-federator latest release"
+#    kind: "githubrelease"
+#    spec:
+#      owner: "rancher"
+#      repository: "prometheus-federator"
+#      token: "{{ requiredEnv .github.token }}"
+#      branch: "main"
+#      versionfilter:
+#        kind: "latest"
+#    transformers:
+#      - trimprefix: "v"
+#
+#conditions:
+#  shell-image-dockerhub:
+#    name: "Check rancher/shell image version in DockerHub"
+#    kind: "dockerimage"
+#    sourceid: "shell-git-tag"
+#    spec:
+#      image: "rancher/shell"
+#  shell-image-helm-project-1:
+#    name: "Check rancher/shell image version in Helm Project Operator chart"
+#    kind: "yaml"
+#    scmid: "helm-project-operator"
+#    disablesourceinput: true
+#    spec:
+#      file: "charts/helm-project-operator/values.yaml"
+#      key: "cleanup[0].image.repository"
+#      value: "rancher/shell"
+#  shell-image-helm-project-2:
+#    name: "Check rancher/shell image version in Helm Project Operator chart"
+#    kind: "yaml"
+#    scmid: "helm-project-operator"
+#    sourceid: "shell-git-tag"
+#    spec:
+#      file: "charts/helm-project-operator/values.yaml"
+#      key: "cleanup[0].image.tag"
+#  shell-image-prometheus-federator:
+#    name: "Check rancher/shell image in prometheus-federator"
+#    kind: "yaml"
+#    scmid: "prometheus-federator"
+#    disablesourceinput: true
+#    spec:
+#      file: 'charts/prometheus-federator/{{ source "prometheus-federator-release" }}/charts/helmProjectOperator/values.yaml'
+#      key: "cleanup[0].image.repository"
+#      value: "rancher/shell"
+#
+#targets:
+#  commit-bump-version:
+#    name: "Update Helm Project Generator go.mod and git commit version"
+#    kind: "shell"
+#    scmid: "prometheus-federator"
+#    sourceid: "helm-project-operator-commit-hash"
+#    spec:
+#      command: "../../updatecli/scripts/prometheus-federator-update-commit-hash.sh"
+#      environments:
+#        - name: PATH
+#        - name: HOME
+#  commit-make-chart:
+#    name: "Make Prometheus Federator chart"
+#    kind: "shell"
+#    scmid: "prometheus-federator"
+#    dependson:
+#      - "commit-bump-version"
+#    disablesourceinput: true
+#    spec:
+#      command: "../../updatecli/scripts/prometheus-federator-make-chart.sh"
+#      environments:
+#        - name: PATH
+#        - name: HOME
+#


### PR DESCRIPTION
Temporarily remove `rancher/shell` image bump in `prometheus-federator`, because it will require some rewrite in the [`git commit id`](https://github.com/rancherlabs/updatecli-automation/blob/main/updatecli/updatecli.d/rancher/shell/prometheus-federator/shell.yaml#L99-L107) and https://github.com/rancherlabs/updatecli-automation/issues/20.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>