### PR TITLE
Fix UpdateCLI broken GH Actions workflow

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Apply Updatecli
         # Never use '--debug' option, because it might leak the access tokens.
-        run: "updatecli apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml"
+        run: "updatecli apply --clean --config updatecli/updatecli.d/ --values updatecli/values.yaml"
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.SECURITY_UPDATECLI_AUTOMATION }}


### PR DESCRIPTION
Fix UpdateCLI broken GH Actions workflow failing due to `./` when passing the arguments and values - https://github.com/rancherlabs/updatecli-automation/actions/runs/4292769343/jobs/7479618448