### PR TITLE
Remove unneeded rancher/shell update from rancher/rancher

### DIFF
--- a/updatecli/updatecli.d/rancher/shell/rancher/v2.6/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/rancher/v2.6/shell.yaml
@@ -56,21 +56,4 @@ targets:
       file: "pkg/settings/setting.go"
       matchpattern: '"rancher/shell:v\d+\.\d+\.\d+.*"'
       replacepattern: '"rancher/shell:{{ source `shell` }}"'
-  tests-framework-extensions-clusters-import:
-    name: "Update rancher/shell image version in release/v2.6/tests/framework/extensions/clusters/import.go"
-    kind: "file"
-    scmid: "rancher"
-    sourceid: "shell"
-    spec:
-      file: "tests/framework/extensions/clusters/import.go"
-      matchpattern: '"rancher/shell:v\d+\.\d+\.\d+.*"'
-      replacepattern: '"rancher/shell:{{ source `shell` }}"'
-  tests-v2-validation-charts-monitoring:
-    name: "Update rancher/shell image version in release/v2.6/tests/v2/validation/charts/monitoring.go"
-    kind: "file"
-    scmid: "rancher"
-    sourceid: "shell"
-    spec:
-      file: "tests/v2/validation/charts/monitoring.go"
-      matchpattern: '"rancher/shell:v\d+\.\d+\.\d+.*"'
-      replacepattern: '"rancher/shell:{{ source `shell` }}"'
+

--- a/updatecli/updatecli.d/rancher/shell/rancher/v2.7/shell.yaml
+++ b/updatecli/updatecli.d/rancher/shell/rancher/v2.7/shell.yaml
@@ -56,22 +56,4 @@ targets:
       file: "pkg/settings/setting.go"
       matchpattern: '"rancher/shell:v\d+\.\d+\.\d+.*"'
       replacepattern: '"rancher/shell:{{ source `shell` }}"'
-  tests-framework-extensions-clusters-import:
-    name: "Update rancher/shell image version in release/v2.7/tests/framework/extensions/clusters/import.go"
-    kind: "file"
-    scmid: "rancher"
-    sourceid: "shell"
-    spec:
-      file: "tests/framework/extensions/clusters/import.go"
-      matchpattern: '"rancher/shell:v\d+\.\d+\.\d+.*"'
-      replacepattern: '"rancher/shell:{{ source `shell` }}"'
-  tests-v2-validation-charts-monitoring:
-    name: "Update rancher/shell image version in release/v2.7/tests/v2/validation/charts/monitoring.go"
-    kind: "file"
-    scmid: "rancher"
-    sourceid: "shell"
-    spec:
-      file: "tests/v2/validation/charts/monitoring.go"
-      matchpattern: '"rancher/shell:v\d+\.\d+\.\d+.*"'
-      replacepattern: '"rancher/shell:{{ source `shell` }}"'
 


### PR DESCRIPTION
Remove unneeded `rancher/shell` update from `rancher/rancher` after simplifications done in https://github.com/rancher/rancher/pull/40579 and https://github.com/rancher/rancher/pull/40923. This will fix failing pipeline https://github.com/rancherlabs/updatecli-automation/actions/runs/4510984380.